### PR TITLE
Remove const for escape_default and escape_unicode

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -390,9 +390,8 @@ impl char {
     /// assert_eq!('❤'.escape_unicode().to_string(), "\\u{2764}");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_escape_unicode", since = "1.50.0")]
     #[inline]
-    pub const fn escape_unicode(self) -> EscapeUnicode {
+    pub fn escape_unicode(self) -> EscapeUnicode {
         let c = self as u32;
 
         // or-ing 1 ensures that for c==0 the code computes that one
@@ -518,9 +517,8 @@ impl char {
     /// assert_eq!('"'.escape_default().to_string(), "\\\"");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_escape_default", since = "1.50.0")]
     #[inline]
-    pub const fn escape_default(self) -> EscapeDefault {
+    pub fn escape_default(self) -> EscapeDefault {
         let init_state = match self {
             '\t' => EscapeDefaultState::Backslash('t'),
             '\r' => EscapeDefaultState::Backslash('r'),


### PR DESCRIPTION
I tried to use `to_ascii_lowercase` in a const context, but was greeter by a surprising message that `to_ascii_lowercase` was not const. I saw that your pull request at https://github.com/rust-lang/rust/pull/79549 aims to fix this!

I have opened this pull request, because I wanted to contribute to your PR at https://github.com/rust-lang/rust/pull/79549. I have removed the `const` declarations from `escape_default` and `escape_unicode` to address the two comments on your PR.